### PR TITLE
ci: create a GitHub release on PR merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+# Creates a GitHub release whenever a PR merges to main, using the module
+# version pinned in ESLZ/SRV-Windows.tf's own source ref as the release tag —
+# that ref is what module callers actually consume, so it's the only version
+# number that matters here.
+#
+# Idempotent by design: most PRs merging to main won't bump the ESLZ ref (e.g.
+# a docs or CI-only change), so the "release already exists" check makes this
+# a no-op for those merges instead of failing or creating a duplicate/empty
+# release.
+name: Release on merge
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: main
+
+      - name: Extract version from ESLZ/SRV-Windows.tf
+        id: version
+        run: |
+          VERSION=$(grep -oP 'ref=\Kv[0-9]+\.[0-9]+\.[0-9]+' ESLZ/SRV-Windows.tf | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract a vX.Y.Z ref from ESLZ/SRV-Windows.tf"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether this version is already released
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # PR title/body are untrusted user input - passed only via env vars
+      # (never interpolated directly into the run: script) to avoid shell/
+      # script injection. See:
+      # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          NOTES="$PR_BODY"
+          if [ -z "$NOTES" ]; then
+            NOTES="No description provided in PR #$PR_NUMBER ($PR_TITLE)."
+          fi
+          printf '%s' "$NOTES" > /tmp/release-notes.md
+
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file /tmp/release-notes.md \
+            --target main


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml`: creates a GitHub release automatically whenever a PR merges to `main`.

- **Version source:** extracted from `ESLZ/SRV-Windows.tf`'s own module `source = "...?ref=vX.Y.Z"` - this is the exact ref module callers consume, so it's the only version number that should drive a release (not, say, a separate manually-bumped version file that could drift from what's actually callable).
- **Idempotent:** most PRs merging to `main` won't touch the ESLZ ref (docs fixes, CI tweaks, etc.) - the workflow checks `gh release view` first and no-ops if that version is already released, instead of failing or creating a duplicate/empty release.
- **Release notes:** the merged PR's title/body become the release title/notes. Falls back to a generic `No description provided in PR #N (title)` if the PR body is empty.
- **Security:** PR title/body are untrusted input from whoever opened the PR. They're passed to the release-creation step only via `env:` variables and referenced as `"$PR_BODY"`/`"$PR_TITLE"` - never interpolated directly into the `run:` script - to avoid a classic [GitHub Actions script-injection](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) vulnerability (e.g. a PR body containing `` `$(...)` `` or backticks).

## Test Plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` - workflow YAML parses cleanly
- [ ] First real merge to `main` that bumps the ESLZ ref will confirm the release is created with the correct tag/title/notes (can't dry-run a `pull_request: closed` trigger locally)
